### PR TITLE
Dash regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
-Outputs word counts in a text file, while transforming words to their base forms e.g.:  
-`teilgenommen` -> `teilnehmen`  
-`seiner` -> `sein`  
+# Lexikon
+
+<img width="263" src="https://cloud.githubusercontent.com/assets/381895/20901807/8d964852-bb34-11e6-9150-245bdaadb35a.png">
+
+Outputs word counts in a text file, while transforming words to their base forms e.g.:
+
+`teilgenommen` -> `teilnehmen`
+
+`seiner` -> `sein`
+
 `Schüle` -> `Schule`
 
-output example:
+Output example:
 ```
 1420 sein
 1348 und
@@ -11,13 +18,17 @@ output example:
 707 der
 705 ein
 612 die
-546 zu```
+546 zu
+```
 
+Uses [http://www.clips.ua.ac.be/pages/pattern-de](http://www.clips.ua.ac.be/pages/pattern-de)
 
-uses: http://www.clips.ua.ac.be/pages/pattern-de
+### Install:
+```
+pip install pattern
+```
 
-install:
-`pip install pattern`
-
-run:  
-`PYTHONIOENCODING=utf-8 words.py your-book-name.txt > words-from-the-book.txt`
+### Run
+```
+PYTHONIOENCODING=utf-8 ./words.py your-book-name.txt > words-from-the-book.txt
+```

--- a/words.py
+++ b/words.py
@@ -1,14 +1,15 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # coding: utf-8
 # run with PYTHONIOENCODING=utf-8
 
 import sys
 import re
+import codecs
 
 # not used, but possibly interesting http://www.nltk.org/
 
 # http://www.clips.ua.ac.be/pages/pattern-de
-from pattern.de import  lemma, tag, predicative, singularize
+from pattern.de import lemma, tag, predicative, singularize
 
 # possible parts of speech:
 # PRP$, FW, VBN, WDT, JJ, WP, DT, RP, NN, TO, PRP,
@@ -23,7 +24,7 @@ part_of_speech_command = {
 }
 
 pattern_word = re.compile('[a-zA-Z]')
-pattern_dash = re.compile('[—-]')
+pattern_punctuation = re.compile(ur'—-|[«»…–<>]')
 
 def transform(tagword):
     word = tagword[0]
@@ -47,10 +48,10 @@ def transform(tagword):
 def main(filepath):
     text = ''
 
-    with open(filepath, 'r') as f:
+    with codecs.open(filepath, 'r', 'utf-8') as f:
         text = f.read()
 
-    text = pattern_dash.sub(' ', text)
+    text = pattern_punctuation.sub(' ', text)
     tagged_words = tag(text)
 
     word_counts = {}


### PR DESCRIPTION
I had to use the `codecs` module, because it gave me errors about Unicode, even though I called the script with `PYTHONIOENCODING=utf-8`.

Plus, added the Unicode quotes and some other symbols to the replacement pattern.